### PR TITLE
Change url of Tabler Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ If you are familiar with [Github](https://github.com/hkalant/EducationalToolsRes
 * [Storyset](https://storyset.com/)
 * [SVG Repo](https://www.svgrepo.com/)
 * [SystemUI icons](https://systemuicons.com)
-* [Tabler icons](https://tablericons.com)
+* [Tabler Icons](https://tabler-icons.io)
 * [Undraw](https://undraw.co/)
 
 ### Image Creation


### PR DESCRIPTION
Official website of Tabler Icons is tabler-icons.io. tablericons.com is in no way associated with our project

Paweł,
author of Tabler Icons