### PR TITLE
Add MathCalculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ If you are familiar with [Github](https://github.com/hkalant/EducationalToolsRes
 ### Utilities
 * [Place it](https://placeit.net/)
 * [Linkpack](https://linkpack.io)
+* [MathCalculator](https://mathcalculator.org/) - Free online math calculators (104+) with step-by-step solutions, multi-language support, and embeddable widgets for classroom use.
 * [Quotes Cover](https://quotescover.com)
 
 ### Video Authoring/Editing


### PR DESCRIPTION
Adds [MathCalculator.org](https://mathcalculator.org) — a free edtech platform with 104+ math calculators covering algebra, calculus, statistics, and geometry. Step-by-step solutions (no paywall), multi-language support (EN/DE/ES), and embeddable widgets for LMS/classroom use.