### PR TITLE
Add QuiQui (open-source live audience response tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ If you are familiar with [Github](https://github.com/hkalant/EducationalToolsRes
 * [Mentimeter](https://www.mentimeter.com/)
 * [Poll Everywhere](https://www.polleverywhere.com)
 * [Socrative](https://www.socrative.com)
+* [QuiQui](https://github.com/th-nuernberg/quiqui) - Live audience response tool for lectures; students answer via QR code, the class sees live results. Self-hosted, open source.
 
 ### Forms/Surveys
 * [Google Forms](https://docs.google.com/forms/)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ If you are familiar with [Github](https://github.com/hkalant/EducationalToolsRes
 * [Mentimeter](https://www.mentimeter.com/)
 * [Poll Everywhere](https://www.polleverywhere.com)
 * [Socrative](https://www.socrative.com)
-* [QuiQui](https://github.com/th-nuernberg/quiqui) - Live audience response tool for lectures; students answer via QR code, the class sees live results. Self-hosted, open source.
+* [QuiQui](https://github.com/th-nuernberg/quiqui) - Live audience response tool for lectures; students answer via QR code, the class sees live results. Questions are authored as YAML in a GitHub repo and support Markdown and LaTeX math. Self-hosted, open source.
 
 ### Forms/Surveys
 * [Google Forms](https://docs.google.com/forms/)


### PR DESCRIPTION
Adds **QuiQui** to the Electronic Voting section.

QuiQui is a free, open-source, self-hostable live audience response tool built for university lectures: a lecturer poses a question, students answer on their phones via a QR code, and the class sees a live result chart. Questions are loaded from a Git repo — no database, no accounts, no build step.

- Repo: https://github.com/th-nuernberg/quiqui
- License: AGPL-3.0
- Actively maintained (v1.0.0 released)
